### PR TITLE
Adding support for white spaces in directories

### DIFF
--- a/src/main/shell/run-sonar.sh
+++ b/src/main/shell/run-sonar.sh
@@ -240,7 +240,7 @@ else
 	echo $projectFile | sed -n 1'p' | tr ',' '\n' > tmpFileRunSonarSh
 	while read projectName; do
 	
-		coverageFilesPath=$(grep 'command' compile_commands.json | sed 's#^.*-o \\/#\/#;s#",##' | grep "${projectName%%.*}.build" | awk 'NR<2' | xargs dirname)
+		coverageFilesPath=$(grep 'command' compile_commands.json | sed 's#^.*-o \\/#\/#;s#",##' | grep "${projectName%%.*}.build" | awk 'NR<2' | sed 's/\\\//\//g' | sed 's/\\\\//g' | xargs -0 dirname)
 		if [ "$vflag" = "on" ]; then
 			echo
 			echo "Path for .gcno/.gcda coverage files is: $coverageFilesPath"
@@ -260,7 +260,7 @@ else
 		fi
 	
 		# Run gcovr with the right options
-		runCommand "sonar-reports/coverage-${projectName%%.*}.xml" gcovr -r . $coverageFilesPath $excludedCommandLineFlags --xml 
+		runCommand "sonar-reports/coverage-${projectName%%.*}.xml" gcovr -r . "$coverageFilesPath" $excludedCommandLineFlags --xml 
 
 	done < tmpFileRunSonarSh
 	rm -rf tmpFileRunSonarSh


### PR DESCRIPTION
Adding support for specific test configuration + potential white spaces in directories :
-> if your configuration was called "Unit Test" for example the script crashed (miserably).
-> if you had a specific configuration for unit testing (different from the one you use for running : typically Debug), this was trying to look for gcda files in the Debug/$project.build folder. This now generates the compile-command.json out of the test scheme build configuration where the GCDA will sit when the tests are done.

////// OLD
Commented workaround for flawed compile-commands.json with OCLINT :
Some versions of xctool don't generate a compile-commands.json or generate a flawed one. Didn't take time to list the flawed versions of xctool or investigate more. Found a workaround building the app up manually with xcodebuild which is acceptable in my case.

Hint for surefire not picking up junit reports :
Default sonarqube setup comes with surefire plugin 1.5. This doesn't support the property : sonar.junit.reportsPath. You've got to go with : sonar.surefire.reportsPath=sonar-reports/
Plus for some reason I didn't take time to investigate, it looks like with version 2.3 you need both properties...
////// OLD