### PR TITLE
Fixed OClint Include Path

### DIFF
--- a/src/main/shell/run-sonar.sh
+++ b/src/main/shell/run-sonar.sh
@@ -277,7 +277,7 @@ if [ "$oclint" = "on" ]; then
 	includedCommandLineFlags=""
 	echo "$srcDirs" | sed -n 1'p' | tr ',' '\n' > tmpFileRunSonarSh
 	while read word; do
-		includedCommandLineFlags+=" --include .*/${currentDirectory}/${word}.*"
+		includedCommandLineFlags+=" --include .*/${currentDirectory}/${word}"
 	done < tmpFileRunSonarSh
 	rm -rf tmpFileRunSonarSh
 	if [ "$vflag" = "on" ]; then


### PR DESCRIPTION
oclint was called with the wrong include paths when given the following project directory structure:
[root]
	projectname
		projectname
			<source files in subdirectories>
		projectname.xcodeproj

sonar.sources was set to projectname/projectname

the appended .* on the includedCommandLineFlags seemed unnecessary - the command execution works when removing it, and oclint also includes subdirectories recursively