### PR TITLE
Prevent bash file expansions breaking the script

### DIFF
--- a/src/main/shell/run-sonar.sh
+++ b/src/main/shell/run-sonar.sh
@@ -277,7 +277,7 @@ if [ "$oclint" = "on" ]; then
 	includedCommandLineFlags=""
 	echo "$srcDirs" | sed -n 1'p' | tr ',' '\n' > tmpFileRunSonarSh
 	while read word; do
-		includedCommandLineFlags+=" --include .*/${currentDirectory}/${word}.*"
+		includedCommandLineFlags+=" --include '.*/${currentDirectory}/${word}.*'"
 	done < tmpFileRunSonarSh
 	rm -rf tmpFileRunSonarSh
 	if [ "$vflag" = "on" ]; then


### PR DESCRIPTION
Fixes an issue where the oclint-json-compilation-database call fails if there is an .xcworkspace and a .xcproj due to bash filename expansions
