### PR TITLE
Comment out the conditions in function insertZeroWhenNoReports

### DIFF
--- a/src/main/java/org/sonar/plugins/objectivec/tests/SurefireParser.java
+++ b/src/main/java/org/sonar/plugins/objectivec/tests/SurefireParser.java
@@ -78,9 +78,9 @@ public class SurefireParser {
     }
 
     private void insertZeroWhenNoReports(Project pom, SensorContext context) {
-        if ( !StringUtils.equalsIgnoreCase("pom", pom.getPackaging())) {
+    //    if ( !StringUtils.equalsIgnoreCase("pom", pom.getPackaging())) {
             context.saveMeasure(CoreMetrics.TESTS, 0.0);
-        }
+    //    }
     }
 
     private void parseFiles(SensorContext context, File[] reports) {


### PR DESCRIPTION
API getPackaging() was deprecated with SonarQube 2.8. With this change,  after build and deploy, the plugin can be used with SonarQube 4.5.6, but can NOT be used with SonarQube 5.2 as violations api was also deprecated and has been removed in sonarqube5.2. 
